### PR TITLE
K2PB demo

### DIFF
--- a/kotlin-fit-converter-lib/build.gradle.kts
+++ b/kotlin-fit-converter-lib/build.gradle.kts
@@ -1,5 +1,4 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import java.io.FileWriter
 
 /*
@@ -25,7 +24,7 @@ plugins {
     id("org.jetbrains.dokka") version "1.9.20"
 
     //K2PB - Protobuf
-    id("com.glureau.k2pb") version "0.9.24"
+    id("com.glureau.k2pb") version "0.9.25"
 
     `maven-publish`
     jacoco
@@ -68,6 +67,7 @@ kotlin {
     sourceSets {
         // Use the old Java-style source directories
         val jvmMain by getting {
+            kotlin.srcDir("build/generated/ksp/metadata/commonMain/kotlin")
             kotlin.srcDir("src/main/kotlin")
             resources.srcDir("src/main/resources")
 
@@ -82,7 +82,6 @@ kotlin {
         val jvmTest by getting {
             kotlin.srcDir("src/test/kotlin")
             resources.srcDir("src/test/resources")
-
             dependencies {
                 // Use the Kotlin JUnit 5 integration.
                 implementation("org.jetbrains.kotlin:kotlin-test-junit5")
@@ -94,10 +93,9 @@ kotlin {
         }
     }
 }
-
-// Temporary workaround, k2pb plugin should handle that automatically
 dependencies {
-    ksp("com.glureau.k2pb:k2pb-compiler:0.9.24")
+    // Temporary solution, k2pb plugin should handle that automatically
+    ksp("com.glureau.k2pb:k2pb-compiler:0.9.25")
 }
 
 publishing {
@@ -177,7 +175,8 @@ tasks.register("bumpVersionAndUpdateReadme") {
         val readmeFileLines = readmeFile.readLines()
         val updatedReadmeFileLines = readmeFileLines.map { line ->
             if (line.contains("[![Latest Release]")) {
-                val newBadge = "[![Latest Release](https://img.shields.io/badge/$newVersionString-red)](https://github.com/example/garmin-fit-converter/releases)"
+                val newBadge =
+                    "[![Latest Release](https://img.shields.io/badge/$newVersionString-red)](https://github.com/example/garmin-fit-converter/releases)"
                 newBadge
             } else {
                 line

--- a/kotlin-fit-converter-lib/build.gradle.kts
+++ b/kotlin-fit-converter-lib/build.gradle.kts
@@ -95,6 +95,11 @@ kotlin {
     }
 }
 
+// Temporary workaround, k2pb plugin should handle that automatically
+dependencies {
+    ksp("com.glureau.k2pb:k2pb-compiler:0.9.24")
+}
+
 publishing {
     publications {
         create<MavenPublication>("mavenJava") {

--- a/kotlin-fit-converter-lib/src/main/kotlin/kjm/fit/converter/KFitProtobufHandler2.kt
+++ b/kotlin-fit-converter-lib/src/main/kotlin/kjm/fit/converter/KFitProtobufHandler2.kt
@@ -1,0 +1,73 @@
+package kjm.fit.converter
+
+import com.glureau.k2pb.runtime.K2PB
+import com.glureau.k2pb.runtime.decodeFromByteArray
+import com.glureau.k2pb.runtime.encodeToByteArray
+import kjm.fit.converter.out.models.FitFileData
+import kjm.fit.converter.out.models.registerKotlinFitConverterLibCodecs
+import kjm.fit.converter.utils.proto.ProtoBufSchemaGenerator
+import kjm.fit.converter.utils.proto.generateProtoBufSchema
+import kotlinx.serialization.decodeFromHexString
+import kotlinx.serialization.protobuf.ProtoBuf
+import java.io.InputStream
+
+/**
+ * Handles the conversion of FIT files to Protobuf and vice versa.
+ * @constructor Creates a new instance of KFitProtobufHandler.
+ * @property kFitDataClassHandler The KFitDataClassHandler instance to use.
+ * @see KFitDataClassHandler
+ * @see FitFileData
+ */
+class KFitProtobufHandler2 {
+
+    private val kFitDataClassHandler = KFitDataClassHandler()
+
+    private val serializer = K2PB {
+        registerKotlinFitConverterLibCodecs()
+    }
+
+    /**
+     * Converts a FIT file to a Protobuf hex string.
+     * @param fileName The name of the file being converted.
+     * @param source The FIT file to convert as an InputStream.
+     * @return The Protobuf hex string.
+     */
+    @OptIn(ExperimentalStdlibApi::class) // toHexString
+    fun convertFitToProtobufHexString(fileName: String, source: InputStream): String =
+        kFitDataClassHandler.convertToDataClass(fileName, source).let { fitData ->
+            serializer.encodeToByteArray<FitFileData>(fitData)
+                .joinToString("") { it.toHexString() }
+        }
+
+    /**
+     * Converts a FIT file to a Protobuf byte array.
+     * @param fileName The name of the file being converted.
+     * @param source The FIT file to convert as an InputStream.
+     * @return The Protobuf byte array.
+     */
+    fun convertFitToProtobufByteArray(fileName: String, source: InputStream): ByteArray =
+        kFitDataClassHandler.convertToDataClass(fileName, source).let { fitData ->
+            serializer.encodeToByteArray<FitFileData>(fitData)
+        }
+
+    /**
+     * Converts a Protobuf hex string to a FIT file data class.
+     * @param protoBuf The Protobuf hex string to convert.
+     * @return The FIT file data class.
+     */
+    @OptIn(ExperimentalStdlibApi::class) // hexToByte
+    fun convertProtobufHexToFit(protoBuf: String): FitFileData =
+        protoBuf.chunked(2).map { it.hexToByte() }.toByteArray().let {
+            serializer.decodeFromByteArray<FitFileData>(it)!!
+        }
+
+    /**
+     * Converts a Protobuf byte array to a FIT file data class.
+     * @param protoBuf The Protobuf byte array to convert.
+     * @return The FIT file data class.
+     */
+    fun convertProtobufByteArrayToFit(protoBuf: ByteArray): FitFileData =
+        serializer.decodeFromByteArray<FitFileData>(protoBuf)!!
+
+    // proto file are generated at build time
+}

--- a/kotlin-fit-converter-lib/src/main/kotlin/kjm/fit/converter/out/models/FitEvent.kt
+++ b/kotlin-fit-converter-lib/src/main/kotlin/kjm/fit/converter/out/models/FitEvent.kt
@@ -1,5 +1,6 @@
 package kjm.fit.converter.out.models
 
+import com.glureau.k2pb.annotation.ProtoMessage
 import kotlinx.serialization.Serializable
 
 /**
@@ -12,6 +13,7 @@ import kotlinx.serialization.Serializable
  * @param rearGearNum Rear gear number.
  */
 @Serializable
+@ProtoMessage
 data class FitEvent(
     val timestamp: String?,
     val eventType: String?,

--- a/kotlin-fit-converter-lib/src/main/kotlin/kjm/fit/converter/out/models/FitProduct.kt
+++ b/kotlin-fit-converter-lib/src/main/kotlin/kjm/fit/converter/out/models/FitProduct.kt
@@ -1,5 +1,6 @@
 package kjm.fit.converter.out.models
 
+import com.glureau.k2pb.annotation.ProtoMessage
 import kotlinx.serialization.Serializable
 
 /**
@@ -9,6 +10,7 @@ import kotlinx.serialization.Serializable
  * @param manufacturer The manufacturer of the product.
  */
 @Serializable
+@ProtoMessage
 data class FitProduct(
     val productName: String,
     val productDataConnection: String?, // sourceType

--- a/kotlin-fit-converter-lib/src/main/kotlin/kjm/fit/converter/out/models/LocationRecord.kt
+++ b/kotlin-fit-converter-lib/src/main/kotlin/kjm/fit/converter/out/models/LocationRecord.kt
@@ -1,5 +1,6 @@
 package kjm.fit.converter.out.models
 
+import com.glureau.k2pb.annotation.ProtoMessage
 import kotlinx.serialization.Serializable
 
 /**
@@ -16,6 +17,7 @@ import kotlinx.serialization.Serializable
  * @param zone Zone captured.
  */
 @Serializable
+@ProtoMessage
 data class LocationRecord(
     val heartRate: Double?,
     val cadence: Double?,
@@ -38,6 +40,7 @@ data class LocationRecord(
  * @param gpsAccuracy GPS accuracy of the location.
  */
 @Serializable
+@ProtoMessage
 data class Location(
     val latitude: Double,
     val longitude: Double,

--- a/kotlin-fit-converter-lib/src/test/kotlin/kjm/fit/converter/KFitProtobufHandlerTest2.kt
+++ b/kotlin-fit-converter-lib/src/test/kotlin/kjm/fit/converter/KFitProtobufHandlerTest2.kt
@@ -1,0 +1,56 @@
+@file:OptIn(ExperimentalSerializationApi::class)
+
+package kjm.fit.converter
+
+import kotlinx.serialization.ExperimentalSerializationApi
+import org.junit.jupiter.api.Assertions.assertArrayEquals
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.io.File
+
+class KFitProtobufHandlerTest2 {
+
+    private val kFitProtobufHandler = KFitProtobufHandler2()
+
+    @Test
+    fun generateProtobufSchemaProto3() {
+        fun assertGeneratedFile(fileName: String) {
+            val schema = File("build/generated/ksp/jvm/jvmMain/resources/k2pb/kjm/fit/converter/$fileName.proto")
+            val expectedSchema =
+                this.javaClass.classLoader.getResourceAsStream("examples/protobuf/k2pb/$fileName.proto")
+                    ?.bufferedReader().use { it?.readText() }
+            assertEquals(expectedSchema, schema.readText())
+        }
+        var fileCount = 0
+        File("build/generated/ksp/jvm/jvmMain/resources/k2pb/kjm/fit/converter/").listFiles()?.forEach {
+            assertGeneratedFile(it.nameWithoutExtension)
+            fileCount++
+        }
+        assertEquals(5, fileCount)
+    }
+
+    @Test
+    fun convertFitToProtoBufHex() { // Failing but not sure how to help here
+        val protoBuf = kFitProtobufHandler.convertFitToProtobufHexString(
+            "my-test-file",
+            this.javaClass.classLoader.getResourceAsStream("fitfiles/tiny-fit-file.fit")!!
+        )
+        val expectedProtoBuf =
+            this.javaClass.classLoader.getResourceAsStream("examples/protobuf/tiny-fit-file-bytestring.proto")
+                ?.bufferedReader().use { it?.readText() }
+        assertEquals(expectedProtoBuf, protoBuf)
+    }
+
+    @Test
+    fun convertFitToProtobufHexBackToFit() {
+        val fileUnderTest = this.javaClass.classLoader.getResourceAsStream("fitfiles/tiny-fit-file.fit")
+        val copiedFileUnderTest = this.javaClass.classLoader.getResourceAsStream("fitfiles/tiny-fit-file.fit")
+
+        val expectedFitFile = KFitDataClassHandler().convertToDataClass("my-test-file", fileUnderTest!!)
+
+        val protoBuf = kFitProtobufHandler.convertFitToProtobufHexString("my-test-file", copiedFileUnderTest!!)
+        val fitDataConversionBack = kFitProtobufHandler.convertProtobufHexToFit(protoBuf)
+
+        assertEquals(expectedFitFile, fitDataConversionBack)
+    }
+}

--- a/kotlin-fit-converter-lib/src/test/resources/examples/protobuf/k2pb/FitEvent.proto
+++ b/kotlin-fit-converter-lib/src/test/resources/examples/protobuf/k2pb/FitEvent.proto
@@ -1,0 +1,26 @@
+syntax = "proto3";
+
+package kjm.fit.converter;
+
+option java_outer_classname = "FitEventProto";
+
+import "com/glureau/k2pb/ExplicitNullability.proto";
+
+//  A data class for holding various event level data.
+//  Initially this is scoped for Di2 gear changes. But will be expanded to include other events.
+//  @param timestamp Timestamp of the event.
+//  @param eventType Type of event.
+//  @param eventName Name of the event.
+//  @param frontGearNum Front gear number.
+//  @param rearGearNum Rear gear number.
+message FitEvent {
+  string timestamp = 1;
+  com.glureau.k2pb.ExplicitNullability isTimestampNull = 2;
+  string eventType = 3;
+  com.glureau.k2pb.ExplicitNullability isEventTypeNull = 4;
+  string eventName = 5;
+  int32 frontGearNum = 6;
+  com.glureau.k2pb.ExplicitNullability isFrontGearNumNull = 7;
+  int32 rearGearNum = 8;
+  com.glureau.k2pb.ExplicitNullability isRearGearNumNull = 9;
+}

--- a/kotlin-fit-converter-lib/src/test/resources/examples/protobuf/k2pb/FitFileData.proto
+++ b/kotlin-fit-converter-lib/src/test/resources/examples/protobuf/k2pb/FitFileData.proto
@@ -1,0 +1,69 @@
+syntax = "proto3";
+
+package kjm.fit.converter;
+
+option java_outer_classname = "FitFileDataProto";
+
+import "com/glureau/k2pb/ExplicitNullability.proto";
+import "kjm/fit/converter/FitEvent.proto";
+import "kjm/fit/converter/FitProduct.proto";
+import "kjm/fit/converter/LocationRecord.proto";
+
+//  A data class representing the entire FIT file. This is an opinionated view on interesting data points and is subject to change.
+//  It's an effort to collate as much valuable data from as many activity types as possible. Initially though this has scope for cycling and running primarily.
+//  @param activityName The name of the activity.
+//  @param activityStartDateTime The start date and time of the activity.
+//  @param sport The sport of the activity.
+//  @param averageHR Average HR of the activity.
+//  @param maxHR Max HR of the activity.
+//  @param averageCadence Average cadence of the activity.
+//  @param averagePower Average power of the activity.
+//  @param maxPower Max power of the activity.
+//  @param averageCalories Average calories of the activity.
+//  @param averageSpeed Average speed of the activity.
+//  @param maxSpeed Max speed of the activity.
+//  @param averageTemperature Average temperature of the activity.
+//  @param totalAscent Total ascent of the activity.
+//  @param totalDescent Total descent of the activity.
+//  @param totalDistance Total distance of the activity.
+//  @param productsUsed Products used during the activity.
+//  @param events Events during the activity.
+//  @param locationRecords Activity records during the activity.
+//  @see FitProduct
+//  @see FitEvent
+//  @see LocationRecord
+//  @see Location
+message FitFileData {
+  string activityName = 1;
+  string activityStartDateTime = 2;
+  string sport = 3;
+  double averageHR = 4;
+  com.glureau.k2pb.ExplicitNullability isAverageHRNull = 5;
+  double maxHR = 6;
+  com.glureau.k2pb.ExplicitNullability isMaxHRNull = 7;
+  double averageCadence = 8;
+  com.glureau.k2pb.ExplicitNullability isAverageCadenceNull = 9;
+  double maxCadence = 10;
+  com.glureau.k2pb.ExplicitNullability isMaxCadenceNull = 11;
+  double averagePower = 12;
+  com.glureau.k2pb.ExplicitNullability isAveragePowerNull = 13;
+  double maxPower = 14;
+  com.glureau.k2pb.ExplicitNullability isMaxPowerNull = 15;
+  double averageCalories = 16;
+  com.glureau.k2pb.ExplicitNullability isAverageCaloriesNull = 17;
+  double averageSpeed = 18;
+  com.glureau.k2pb.ExplicitNullability isAverageSpeedNull = 19;
+  double maxSpeed = 20;
+  com.glureau.k2pb.ExplicitNullability isMaxSpeedNull = 21;
+  double averageTemperature = 22;
+  com.glureau.k2pb.ExplicitNullability isAverageTemperatureNull = 23;
+  int32 totalAscent = 24;
+  com.glureau.k2pb.ExplicitNullability isTotalAscentNull = 25;
+  int32 totalDescent = 26;
+  com.glureau.k2pb.ExplicitNullability isTotalDescentNull = 27;
+  double totalDistance = 28;
+  com.glureau.k2pb.ExplicitNullability isTotalDistanceNull = 29;
+  repeated FitProduct productsUsed = 30;
+  repeated FitEvent events = 31;
+  repeated LocationRecord locationRecords = 32;
+}

--- a/kotlin-fit-converter-lib/src/test/resources/examples/protobuf/k2pb/FitProduct.proto
+++ b/kotlin-fit-converter-lib/src/test/resources/examples/protobuf/k2pb/FitProduct.proto
@@ -1,0 +1,20 @@
+syntax = "proto3";
+
+package kjm.fit.converter;
+
+option java_outer_classname = "FitProductProto";
+
+import "com/glureau/k2pb/ExplicitNullability.proto";
+
+//  A data class representing various products used to record the fit file. Still in progress of being fleshed out.
+//  @param productName The name of the product.
+//  @param productDataConnection The data connection type of the product.
+//  @param manufacturer The manufacturer of the product.
+message FitProduct {
+  string productName = 1;
+  string productDataConnection = 2;
+  com.glureau.k2pb.ExplicitNullability isProductDataConnectionNull = 3;
+  string manufacturer = 4;
+  string description = 5;
+  com.glureau.k2pb.ExplicitNullability isDescriptionNull = 6;
+}

--- a/kotlin-fit-converter-lib/src/test/resources/examples/protobuf/k2pb/Location.proto
+++ b/kotlin-fit-converter-lib/src/test/resources/examples/protobuf/k2pb/Location.proto
@@ -1,0 +1,24 @@
+syntax = "proto3";
+
+package kjm.fit.converter;
+
+option java_outer_classname = "LocationProto";
+
+import "com/glureau/k2pb/ExplicitNullability.proto";
+
+//  Internal representation of location data.
+//  @param latitude Latitude of the location.
+//  @param longitude Longitude of the location.
+//  @param altitude Altitude of the location.
+//  @param grade Grade of the location.
+//  @param gpsAccuracy GPS accuracy of the location.
+message Location {
+  double latitude = 1;
+  double longitude = 2;
+  float altitude = 3;
+  com.glureau.k2pb.ExplicitNullability isAltitudeNull = 4;
+  double grade = 5;
+  com.glureau.k2pb.ExplicitNullability isGradeNull = 6;
+  double gpsAccuracy = 7;
+  com.glureau.k2pb.ExplicitNullability isGpsAccuracyNull = 8;
+}

--- a/kotlin-fit-converter-lib/src/test/resources/examples/protobuf/k2pb/LocationRecord.proto
+++ b/kotlin-fit-converter-lib/src/test/resources/examples/protobuf/k2pb/LocationRecord.proto
@@ -1,0 +1,40 @@
+syntax = "proto3";
+
+package kjm.fit.converter;
+
+option java_outer_classname = "LocationRecordProto";
+
+import "com/glureau/k2pb/ExplicitNullability.proto";
+import "kjm/fit/converter/Location.proto";
+
+//  A data class representing an event during an activity.
+//  @param heartRate HR captured.
+//  @param cadence Cadence captured.
+//  @param power Power captured.
+//  @param location Location Object captured.
+//  @param temperature Temperature captured.
+//  @param speed Speed captured.
+//  @param elevation Elevation captured.
+//  @param timestamp Timestamp of the event.
+//  @param distance Distance captured in meters.
+//  @param zone Zone captured.
+message LocationRecord {
+  double heartRate = 1;
+  com.glureau.k2pb.ExplicitNullability isHeartRateNull = 2;
+  double cadence = 3;
+  com.glureau.k2pb.ExplicitNullability isCadenceNull = 4;
+  double power = 5;
+  com.glureau.k2pb.ExplicitNullability isPowerNull = 6;
+  Location location = 7;
+  double temperature = 8;
+  com.glureau.k2pb.ExplicitNullability isTemperatureNull = 9;
+  double speed = 10;
+  com.glureau.k2pb.ExplicitNullability isSpeedNull = 11;
+  double elevation = 12;
+  com.glureau.k2pb.ExplicitNullability isElevationNull = 13;
+  string timestamp = 14;
+  double distance = 15;
+  com.glureau.k2pb.ExplicitNullability isDistanceNull = 16;
+  int32 zone = 17;
+  com.glureau.k2pb.ExplicitNullability isZoneNull = 18;
+}


### PR DESCRIPTION
I cloned the KFitProtobufHandler to make a similar implementation with K2PB.
A few notes:
- similarly to Ktx, you have to annotate each class (also enum classes)
- in opposition with Ktx, schema are generated at build time (like the classes it represents, there's likely no need for runtime here, but let me know if you have a use case), and documentation is kept to ensure it can be shared with backend or other consumers that only knows about those schemas.
- K2PB has an explicit nullability approach, to distinguish between protobuf default value and null values. For example, a default String is "" for protobuf, and with ktx you can't differentiate between a null and a "" if you don't force encode. And if you do then you don't follow protobuf documentation, which makes it tricky in both cases if you have other clients only using protobuf schema. I opted for an approach to add a dedicated field to handle that nullability explicitely, which also allow to migrate more easily. But this may not be what you want if you already have a protobuf serialized data. I let you update the tests accordingly to see if it can still fit your needs.